### PR TITLE
feat: implement matomo tracking (add and configure)

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,5 @@
+SITE_URL=http://localhost:4200/
+CMS_API=https://backend.ddev.site/wp/graphql/
+GATSBY_NEWSSUBMISSION_URL=
+MATOMO_URL=
+MATOMO_SITE_ID=

--- a/frontend/gatsby-config.js
+++ b/frontend/gatsby-config.js
@@ -78,9 +78,9 @@ module.exports = {
     {
       resolve: "gatsby-plugin-matomo",
       options: {
-        siteId: "1",
-        matomoUrl: "https://analytics.mint-vernetzt.de/",
-        siteUrl: "https://mint-vernetzt.de/",
+        siteId: `${process.env.MATOMO_SITE_ID}`,
+        matomoUrl: `${process.env.MATOMO_URL}`,
+        siteUrl: `${process.env.SITE_URL}`,
       },
     },
   ],

--- a/frontend/gatsby-config.js
+++ b/frontend/gatsby-config.js
@@ -75,5 +75,13 @@ module.exports = {
         path: "src/data/pakt/",
       },
     },
+    {
+      resolve: "gatsby-plugin-matomo",
+      options: {
+        siteId: "1",
+        matomoUrl: "https://analytics.mint-vernetzt.de/",
+        siteUrl: "https://mint-vernetzt.de/",
+      },
+    },
   ],
 };

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,6 +14,7 @@
         "gatsby": "^4.9.3",
         "gatsby-plugin-image": "^2.10.0",
         "gatsby-plugin-manifest": "^4.10.0",
+        "gatsby-plugin-matomo": "^0.13.0",
         "gatsby-plugin-react-helmet": "^5.9.0",
         "gatsby-plugin-sharp": "^4.10.0",
         "gatsby-plugin-svgr": "^3.0.0-beta.0",
@@ -22737,6 +22738,16 @@
       },
       "peerDependencies": {
         "gatsby": "^4.0.0-next"
+      }
+    },
+    "node_modules/gatsby-plugin-matomo": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-matomo/-/gatsby-plugin-matomo-0.13.0.tgz",
+      "integrity": "sha512-zwmxcwOoDi3hjNQoUJehoC5XwQKgR+bArAAvArGJWHlJqv7G688tlmKgbIGqEUj3aFSdyWAzAM7QhEt68buMNw==",
+      "peerDependencies": {
+        "gatsby": "^4.0.0",
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/gatsby-plugin-page-creator": {
@@ -56478,6 +56489,12 @@
         "semver": "^7.3.5",
         "sharp": "^0.30.1"
       }
+    },
+    "gatsby-plugin-matomo": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-matomo/-/gatsby-plugin-matomo-0.13.0.tgz",
+      "integrity": "sha512-zwmxcwOoDi3hjNQoUJehoC5XwQKgR+bArAAvArGJWHlJqv7G688tlmKgbIGqEUj3aFSdyWAzAM7QhEt68buMNw==",
+      "requires": {}
     },
     "gatsby-plugin-page-creator": {
       "version": "4.9.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,6 +28,7 @@
     "gatsby": "^4.9.3",
     "gatsby-plugin-image": "^2.10.0",
     "gatsby-plugin-manifest": "^4.10.0",
+    "gatsby-plugin-matomo": "^0.13.0",
     "gatsby-plugin-react-helmet": "^5.9.0",
     "gatsby-plugin-sharp": "^4.10.0",
     "gatsby-plugin-svgr": "^3.0.0-beta.0",


### PR DESCRIPTION
# TODO
- @phollome please make sure to add the matomo opt-out iframe to the live cms. matomo dsgvo disclaimer is missing as well. The Iframe allows the user to manually opt-out from matomo tracking. for this to work a cookie (from matomo subdomain) is used to save this preference.

# Tasks accomplished: 

## Gatsby
  - local sync
  - read plugin(s) docs
  - install plugin
  - configure plugin
  - read about dev mode
  - deployment(s) to stage
  - Test Deployment

## Matomo:
  - install Custom Opt Out
  - local font download
  - align Matomo CSS with website
  - 
## Worpdpress:
  - add iframe to cms page - pull request - Testing

Closes #21 

## Checklist
- [ ] Tests
- [ ] Documentation